### PR TITLE
Fix replacement of numbers 0 and 1 in permutations

### DIFF
--- a/jasy/core/Permutation.py
+++ b/jasy/core/Permutation.py
@@ -45,9 +45,9 @@ class Permutation:
             
             # Basic translation like in JavaScript frontend
             # We don't have a special threadment for strings, numbers, etc.
-            if isinstance(value, bool) and value == True:
+            if value is True:
                 value = "true"
-            elif isinstance(value, bool) and value == False:
+            elif value is False:
                 value = "false"
             elif value == None:
                 value = "null"


### PR DESCRIPTION
In permutations the code replaces boolean
values with their javascript string counterparts.
This fix prevents replacing 0 and 1 (typeof int)
as they are interpreted as boolean values if not
explicietly checked.
