### PR TITLE
Fix upward directory traversing if no repository is found

### DIFF
--- a/jasy/vcs/Repository.py
+++ b/jasy/vcs/Repository.py
@@ -101,7 +101,10 @@ def getRevision(path):
             revision = svnversion
             break
 
+        cur = os.getcwd()
         os.chdir(os.pardir)
+        if (cur == os.getcwd()):
+            break
         
     os.chdir(old)
     return revision


### PR DESCRIPTION
Getting revision of repository results in infinite loop if no repository was found.
A os.chdir(os.pardir) starting at / results in / as current dir. This leads to the solution
that if current dir equals old current dir there is no more parent directories.
